### PR TITLE
fix "Text file busy" issue during docker build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM openjdk:7
 RUN apt-get update && apt-get install -y maven2
 COPY ./germaner-src /germaner-src
 WORKDIR /germaner-src
-RUN cd /germaner-src && chmod +x build.sh && ./build.sh
+RUN cd /germaner-src && chmod +x build.sh && sleep 1 && ./build.sh
 
 CMD ["java", "-Xmx4096m", "-cp", "./resources/:germaner-server.jar", "de.tu.darmstadt.lt.storyfinder.nerservice.Main"]


### PR DESCRIPTION
--- before:
Step 5/6 : RUN cd /germaner-src && chmod +x build.sh && ./build.sh
 ---> Running in 490c069daee7
/bin/sh: 1: ./build.sh: Text file busy
The command '/bin/sh -c cd /germaner-src && chmod +x build.sh && ./build.sh' returned a non-zero code: 2

--- now: 
Step 5/6 : RUN cd /germaner-src && chmod +x build.sh && sleep 1 && ./build.sh
 ---> Running in 7c62ddf82340
Cloning into 'GermaNER'...
[INFO] Scanning for projects...